### PR TITLE
Bugfix/docs examples use output.read()

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ def stream_direct():
 
 CHANGELOG
 
+DEC 13, 2014:
+- Fix README examples.
+
 JUL 27:
 - Tests
 - Travis


### PR DESCRIPTION
The README examples didn't work for me, I had to use `image.output.read()` rather than `image.read()`
