### PR TITLE
Add basic auth and timeout parameters.

### DIFF
--- a/mjpegtools/__init__.py
+++ b/mjpegtools/__init__.py
@@ -4,15 +4,25 @@ import re
 import time
 import StringIO
 import logging
+from base64 import b64encode
 
 class MjpegParser(object):
-  def __init__(self, url, **kwargs):
+  def __init__(self, url, auth=None, timeout=2):
+    """
+    :param url: The url
+    :param auth: A tuple containing username, password for basic
+                 auth, or none if no auth needed.
+    :param timeout: The timeout value for urllib.urlopen().
+    """
     self.pil = True
     self.quality = 50
     self.format = 'jpeg'
-    self.timeout= 2
+    self.timeout= timeout
+    request = urllib2.Request(url)
     try:
-      self.input = urllib2.urlopen(url, timeout=self.timeout)
+      if auth:
+        request.add_header('Authorization', 'Basic ' + b64encode(auth[0] + ':' + auth[1]) )
+      self.input = urllib2.urlopen(request, timeout=self.timeout)
       self.ping = True
     except:
       logging.error('input error')


### PR DESCRIPTION
Adding auth (username,password) and timeout parameters to `__init__` and urllib2 invocations.  This allows access to password-protected webcam resources.

Simple urllib2 basic auth handling based on [this example](https://gist.github.com/kennethreitz/973705#comment-56387)
